### PR TITLE
Add args array to allow comments

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -13,7 +13,7 @@ MOREARGS=()
     MOREARGS+=(-nographic -vnc :0 -k en-us)
 }
 
-qemu-system-x86_64 \
+args=(
     -enable-kvm \
     -m 4G \
     -machine q35,accel=kvm \
@@ -36,3 +36,6 @@ qemu-system-x86_64 \
     -drive id=SystemDisk,if=none,file="$VMDIR/macOS.qcow2" \
     -device ide-hd,bus=sata.4,drive=SystemDisk \
     "${MOREARGS[@]}"
+)
+
+qemu-system-x86_64 "${args[@]}"

--- a/virtio.sh
+++ b/virtio.sh
@@ -6,7 +6,7 @@ OVMF=$VMDIR/firmware
 #export QEMU_AUDIO_DRV=pa
 #QEMU_AUDIO_DRV=pa
 
-qemu-system-x86_64 \
+args=(
     -nodefaults \
     -enable-kvm \
     -m 4G \
@@ -25,3 +25,6 @@ qemu-system-x86_64 \
     -drive id=ESP,if=virtio,format=qcow2,file="$VMDIR/ESP.qcow2" \
     -drive id=InstallMedia,if=virtio,format=raw,file="$VMDIR/BaseSystem.img" \
     -drive id=MyDisk,if=virtio,format=qcow2,file="$VMDIR/macOS.qcow2" \
+)
+
+qemu-system-x86_64 "${args[@]}"


### PR DESCRIPTION
This pr creates an args variable that contains all startup arguments that will be passed to qemu-system-x86_64.

This allows user to create comments on additional arguments that they may pass, and comment them out accordingly to make it more organizable.