### PR TITLE
Fix SetupArch

### DIFF
--- a/setupArch.sh
+++ b/setupArch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo pacman -S qemu python python3-pip python-wheel -y
+sudo pacman -Syu qemu-desktop python python-pip python-wheel --needed
 
 (ls macOS.qcow2 >> /dev/null 2>&1 && echo "") || qemu-img create -f qcow2 macOS.qcow2 64G
 


### PR DESCRIPTION
Hey so there have been some changes to arch packages and changed it to -Syu. I've explained why below.
python3-pip is called python-pip now because of python 2 deprecation https://archlinux.org/news/removing-python2-from-the-repositories/
Replace -Sy with -Syu as -Sy is considered a partial upgrade which is bad https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported
Add --needed so it doesn't reinstall what's already installed
qemu is now qemu-desktop as it's split into 3 packages groups/meta. https://archlinux.org/news/qemu-700-changes-split-package-setup/
