### PR TITLE
fix virsh not found

### DIFF
--- a/setupFedora.sh
+++ b/setupFedora.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo dnf install qemu qemu-img python3 python3-pip -y
+sudo dnf install qemu qemu-img python3 python3-pip libvirt-client -y
 
 (ls macOS.qcow2 >> /dev/null 2>&1 && echo "") || qemu-img create -f qcow2 macOS.qcow2 64G
 


### PR DESCRIPTION
added libvirt-client to be installed for fedora virt-manager support