### PR TITLE
Update template.xml.in and basic.sh

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -24,7 +24,6 @@ args=(
     -drive if=pflash,format=raw,readonly=on,file="$OVMF/OVMF_CODE.fd" \
     -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
     -vga qxl \
-    -device ich9-intel-hda -device hda-output \
     -usb -device usb-kbd -device usb-tablet \
     -netdev user,id=net0 \
     -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
@@ -36,6 +35,8 @@ args=(
     -device ide-hd,bus=sata.3,drive=InstallMedia \
     -drive id=SystemDisk,if=none,file="$VMDIR/macOS.qcow2" \
     -device ide-hd,bus=sata.4,drive=SystemDisk \
+    -device intel-hda \
+    -device hda-output \
     "${MOREARGS[@]}"
 )
 

--- a/basic.sh
+++ b/basic.sh
@@ -24,6 +24,8 @@ args=(
     -drive if=pflash,format=raw,readonly=on,file="$OVMF/OVMF_CODE.fd" \
     -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
     -vga qxl \
+    -device intel-hda \
+    -device hda-output \
     -usb -device usb-kbd -device usb-tablet \
     -netdev user,id=net0 \
     -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
@@ -35,8 +37,6 @@ args=(
     -device ide-hd,bus=sata.3,drive=InstallMedia \
     -drive id=SystemDisk,if=none,file="$VMDIR/macOS.qcow2" \
     -device ide-hd,bus=sata.4,drive=SystemDisk \
-    -device intel-hda \
-    -device hda-output \
     "${MOREARGS[@]}"
 )
 

--- a/basic.sh
+++ b/basic.sh
@@ -21,11 +21,10 @@ args=(
     -cpu Haswell,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc,+avx2 \
     -device isa-applesmc,osk="$OSK" \
     -smbios type=2 \
+    -device intel-hda -device hda-output \
     -drive if=pflash,format=raw,readonly=on,file="$OVMF/OVMF_CODE.fd" \
-    -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
+    -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS.fd" \
     -vga qxl \
-    -device intel-hda \
-    -device hda-output \
     -usb -device usb-kbd -device usb-tablet \
     -netdev user,id=net0 \
     -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -100,7 +100,7 @@
   </devices>
   <qemu:commandline>
     <qemu:arg value='-cpu'/>
-    <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
+    <qemu:arg value="Haswell,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc,+avx2"/>
     <qemu:arg value='-device'/>
     <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
     <qemu:arg value='-smbios'/>

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -108,6 +108,10 @@
     <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
+    <qemu:arg value="-device"/>
+    <qemu:arg value="intel-hda"/>
+    <qemu:arg value="-device"/>
+    <qemu:arg value="hda-output"/>
   </qemu:commandline>
 </domain>
 

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -86,9 +86,6 @@
       <listen type='address'/>
       <image compression='off'/>
     </graphics>
-    <sound model='ich9'>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1b' function='0x0'/>
-    </sound>
     <video>
       <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>


### PR DESCRIPTION
Adding those quemu args and following with this guide (https://github.com/MobCode100/Dastux/blob/main/VoodooHDA-QEMU-KVM.md) will enable audio playback without passthrough in the macOS VM (tested with Ventura).