### PR TITLE
Fix USB for Sonoma MacOS installer

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -36,6 +36,7 @@ args=(
     -device ide-hd,bus=sata.3,drive=InstallMedia \
     -drive id=SystemDisk,if=none,file="$VMDIR/macOS.qcow2" \
     -device ide-hd,bus=sata.4,drive=SystemDisk \
+    -device qemu-xhci -device usb-kbd -device usb-tablet \
     "${MOREARGS[@]}"
 )
 


### PR DESCRIPTION
Facilitate keyboard and mouse input to get to the Disk Utility

Based on https://www.reddit.com/r/macOSVMs/comments/1bcdx3x/comment/kug3d06/