### PR TITLE
Replace USB controllers with `qemu-xhci` for macOS Sonoma support

### DIFF
--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -44,7 +44,7 @@
       <target dev='sdb' bus='sata'/>
       <address type='drive' controller='0' bus='0' target='0' unit='1'/>
     </disk>
-    <controller type='usb' index='0' model='qemu-xhci' ports='7'>
+    <controller type='usb' index='0' model='qemu-xhci'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x0'/>
     </controller>
     <controller type='sata' index='0'>

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -44,20 +44,8 @@
       <target dev='sdb' bus='sata'/>
       <address type='drive' controller='0' bus='0' target='0' unit='1'/>
     </disk>
-    <controller type='usb' index='0' model='ich9-ehci1'>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x7'/>
-    </controller>
-    <controller type='usb' index='0' model='ich9-uhci1'>
-      <master startport='0'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x0' multifunction='on'/>
-    </controller>
-    <controller type='usb' index='0' model='ich9-uhci2'>
-      <master startport='2'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x1'/>
-    </controller>
-    <controller type='usb' index='0' model='ich9-uhci3'>
-      <master startport='4'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x2'/>
+    <controller type='usb' index='0' model='qemu-xhci' ports='7'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x0'/>
     </controller>
     <controller type='sata' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>


### PR DESCRIPTION
Changes made in this commit will fix #103 by replacing the `ich9-echi1` controller with a `qemu-xhci` controller as recommended on Reddit: <https://www.reddit.com/r/macOSVMs/s/kzSuQrgOgt>.

Setting the address of the controller to `<address type="pci" domain="0x0000" bus="0x01" slot="0x00" function="0x0"/>` (`virt-manager`s default), causes USB devices to not be picked up.

For that reason, the address from this repository was used, which seems to work out just fine:
`<address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x0'/>`.

Unlike recommended on Reddit, the ports does not seem to be necessary. macOS 14.4 works just fine with the changes made in this PR.

When I limited the ports as recommended on Reddit (by adding `ports='7'` to the `controller`-tag), I also had to set `UEFI -> ProtocolOverrides -> HashServices` to `true` in OpenCore's `config.plist` file. Otherwise, a notification "Volume Hash Mismatch" notification was shown each time I booted up the VM.