### PR TITLE
Get latest WSL kernel version for windows-install.sh

### DIFF
--- a/windows-install.sh
+++ b/windows-install.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
-sudo apt update && sudo apt -y upgrade
-sudo apt -y install build-essential libncurses-dev bison flex libssl-dev libelf-dev cpu-checker qemu-kvm aria2 bc
-sudo apt-get install qemu-system qemu-utils python3 python3-pip -y
+
+# Updates and dependencies
+sudo apt -q update && sudo apt -q -y upgrade
+sudo apt -qq -y install build-essential libncurses-dev bison flex libssl-dev libelf-dev cpu-checker aria2 bc qemu-syste>
+
 cd ~
-aria2c -x 10 https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-wsl-5.15.153.1.tar.gz
-tar -xf WSL2-Linux-Kernel-linux-msft-wsl-5.15.153.1.tar.gz
-cd WSL2-Linux-Kernel-linux-msft-wsl-5.15.153.1/
+
+# Download latest kernel version
+latest=$(curl -s "https://api.github.com/repos/microsoft/WSL2-Linux-Kernel/releases" | jq -r '.[0].name')
+echo "Latest version is $latest"
+aria2c -x 10 --allow-overwrite=true --download-result=hide --summary-interval=0 https://github.com/microsoft/WSL2-Linux>
+
+# Extract and start build process
+pv WSL2-Linux-Kernel-$latest.tar.gz | tar -xz
+cd WSL2-Linux-Kernel-$latest/
 cp Microsoft/config-wsl .config
 make menuconfig
+
 cd ~

--- a/windows-install.sh
+++ b/windows-install.sh
@@ -25,7 +25,11 @@ echo "Using kernel version: $latest"
 aria2c -x 10 --allow-overwrite=true --download-result=hide --summary-interval=0 https://github.com/microsoft/WSL2-Linux>
 
 # Extract and start build process
-pv WSL2-Linux-Kernel-$latest.tar.gz | tar -xz
+if command -v pv >/dev/null 2>&1; then
+    pv WSL2-Linux-Kernel-$latest.tar.gz | tar -xz
+else
+    tar -xzvf WSL2-Linux-Kernel-$latest.tar.gz
+fi
 cd WSL2-Linux-Kernel-$latest/
 cp Microsoft/config-wsl .config
 make menuconfig

--- a/windows-install.sh
+++ b/windows-install.sh
@@ -7,7 +7,15 @@ sudo apt -qq -y install build-essential libncurses-dev bison flex libssl-dev lib
 cd ~
 
 # Download latest kernel version
-latest=$(curl -s "https://api.github.com/repos/microsoft/WSL2-Linux-Kernel/releases" | jq -r '.[0].name')
+if ! latest=$(curl -s "https://api.github.com/repos/microsoft/WSL2-Linux-Kernel/releases" | jq -r '.[0].name'); then
+    echo "Error: Failed to fetch latest version from GitHub API"
+    exit 1
+fi
+
+if [ -z "$latest" ]; then
+    echo "Error: Failed to parse version information"
+    exit 1
+fi
 echo "Latest version is $latest"
 aria2c -x 10 --allow-overwrite=true --download-result=hide --summary-interval=0 https://github.com/microsoft/WSL2-Linux>
 

--- a/windows-install.sh
+++ b/windows-install.sh
@@ -17,6 +17,11 @@ if [ -z "$latest" ]; then
     exit 1
 fi
 echo "Latest version is $latest"
+if [ -z "$latest" ]; then
+    echo "Failed to fetch latest version. Using fallback version."
+    latest="5.10.102.1"
+fi
+echo "Using kernel version: $latest"
 aria2c -x 10 --allow-overwrite=true --download-result=hide --summary-interval=0 https://github.com/microsoft/WSL2-Linux>
 
 # Extract and start build process


### PR DESCRIPTION
- Removed qemu-kvm cause that is deprecated
- Added comments
- Added more progress bars

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the windows-install.sh script to automatically fetch the latest WSL kernel version, enhance user feedback with progress bars, and improve script readability with comments and quieter command outputs.

New Features:
- Automatically fetch the latest WSL kernel version from the GitHub API for installation.

Enhancements:
- Add progress bars to the script using 'pv' for better user feedback during the extraction process.
- Improve script output by adding comments and using quieter options for package management commands.

<!-- Generated by sourcery-ai[bot]: end summary -->