### PR TITLE
Trying to fix `windows-install.sh` to fix #115

### DIFF
--- a/windows-install.sh
+++ b/windows-install.sh
@@ -2,7 +2,7 @@
 
 # Updates and dependencies
 sudo apt -q update && sudo apt -q -y upgrade
-sudo apt -qq -y install build-essential libncurses-dev bison flex libssl-dev libelf-dev cpu-checker aria2 bc qemu-syste>
+sudo apt -q -y install build-essential libncurses-dev bison flex libssl-dev libelf-dev cpu-checker aria2 bc qemu-system
 
 cd ~
 
@@ -22,7 +22,7 @@ if [ -z "$latest" ]; then
     latest="5.10.102.1"
 fi
 echo "Using kernel version: $latest"
-aria2c -x 10 --allow-overwrite=true --download-result=hide --summary-interval=0 https://github.com/microsoft/WSL2-Linux>
+aria2c -x 10 --allow-overwrite=true --download-result=hide --summary-interval=0 https://github.com/microsoft/WSL2-Linux-Kernel/archive/$latest.tar.gz
 
 # Extract and start build process
 if command -v pv >/dev/null 2>&1; then

--- a/windows-install.sh
+++ b/windows-install.sh
@@ -19,7 +19,7 @@ fi
 echo "Latest version is $latest"
 if [ -z "$latest" ]; then
     echo "Failed to fetch latest version. Using fallback version."
-    latest="5.10.102.1"
+    latest="linux-msft-wsl-5.10.102.1"
 fi
 echo "Using kernel version: $latest"
 aria2c -x 10 --allow-overwrite=true --download-result=hide --summary-interval=0 https://github.com/microsoft/WSL2-Linux-Kernel/archive/$latest.tar.gz


### PR DESCRIPTION
Was trying it out today, but got some line error issues. Turns out `windows-install.sh` is from a recent PR #113.

Detailed my issue in #115. Basically some lines seem to be replaced by `>` angle bracket? Possibly merging issue? But then @notAperson535 confirmed the PR to be working on his side.

So all in all, I was unsure why the original PR included that, but here's a version that worked perfectly on my side.

Also fixed the fallback for tagging, since for example: https://github.com/microsoft/WSL2-Linux-Kernel/releases/tag/5.10.102.1 is invalid. If successful, latest produce the full tag: `linux-msft-wsl-5.10.102.1`, so the fallback should follow the same format.

Sorry if I'm wrong.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix errors in `windows-install.sh` by removing an incorrect angle bracket in the package installation command and updating the fallback version tag format to ensure compatibility with the expected kernel versioning.

Bug Fixes:
- Correct the installation command in `windows-install.sh` by removing an erroneous angle bracket that was causing line errors.
- Fix the fallback version tag format in `windows-install.sh` to ensure it matches the expected format for kernel versioning.

<!-- Generated by sourcery-ai[bot]: end summary -->