### PR TITLE
remove audio devices from libvirt template

### DIFF
--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -93,10 +93,6 @@
     <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
-    <qemu:arg value="-device"/>
-    <qemu:arg value="intel-hda"/>
-    <qemu:arg value="-device"/>
-    <qemu:arg value="hda-output"/>
   </qemu:commandline>
 </domain>
 


### PR DESCRIPTION
They can prevent the VM from starting because of error
```
qemu-system-x86_64: -device hda-output: no default audio driver available
Perhaps you wanted to use -audio or set audiodev=audio1?
```

See https://github.com/notAperson535/OneClick-macOS-Simple-KVM/issues/119